### PR TITLE
fix bug on use full context

### DIFF
--- a/web/chat/script.js
+++ b/web/chat/script.js
@@ -323,10 +323,10 @@ async function generateResponse() {
         button.disabled = false;
         selectedImage = null;
         document.getElementById('imagePreview').innerHTML = '';
+        
+        // After getting the AI response, store it
+        conversationHistory.push({ role: 'assistant', content: fullResponse });
     }
-
-    // After getting the AI response, store it
-    conversationHistory.push({ role: 'assistant', content: fullResponse });
 }
 
 // Enter key to submit


### PR DESCRIPTION
issue: 
when full context is enabled, var fullResponse nullPointer/not defined
![image](https://github.com/user-attachments/assets/500235dd-5711-4323-914a-15ed2aa2197d)

due to var fullContext declared within the try/catch case at script.js:292. 
When exiting the try/catch case var fullContext is no longer available at script.js:329:
![image](https://github.com/user-attachments/assets/306f01b1-09ad-4343-9204-4a374176d2b7)

fix: 
moving push action onto conversationHistory into final case. 

side effect:
no side effects.
![image](https://github.com/user-attachments/assets/3b36fd9d-32c1-4856-96d6-b54bf637951c)


